### PR TITLE
fix typo in ChordTween call & yaml.load deprecation warning

### DIFF
--- a/braid/thread.py
+++ b/braid/thread.py
@@ -330,17 +330,17 @@ Thread.setup()
 synths = {}
 try:
     with open(os.path.join(os.getcwd(), "synths.yaml")) as f:
-        synths.update(yaml.load(f))
+        synths.update(yaml.load(f, Loader=yaml.FullLoader))
 except FileNotFoundError as e:
     pass
 try:
     with open(os.path.join(os.path.dirname(__file__), "..", "synths.yaml")) as f:
-        synths.update(yaml.load(f))
+        synths.update(yaml.load(f, Loader=yaml.FullLoader))
 except FileNotFoundError as e:
     pass
 try:
     with open("/usr/local/braid/synths.yaml") as f:
-        synths.update(yaml.load(f))
+        synths.update(yaml.load(f, Loader=yaml.FullLoader))
 except FileNotFoundError as e:
     pass
 if len(synths):

--- a/braid/tween.py
+++ b/braid/tween.py
@@ -110,7 +110,7 @@ def tween(value, cycles, signal_f=linear(), on_end=None, osc=False, saw=False, s
     if type(value) == int or type(value) == float:
         return ScalarTween(value, cycles, signal_f, on_end, osc, saw, start)
     if type(value) == tuple:
-        return ChordTween(value, cycles, signal_f, one_end, osc, saw, start)
+        return ChordTween(value, cycles, signal_f, on_end, osc, saw, start)
     if type(value) == list: # careful, lists are always patterns
         value = Pattern(value)
     if type(value) == Pattern:


### PR DESCRIPTION
`one_end` should be `on_end`

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation